### PR TITLE
Handle all special characters in defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ var parseString = (function (){
 
   // This regular expression detects instances of the
   // template parameter syntax such as {{foo}} or {{foo:someDefault}}.
-  var regex = /{{(\w|:|\s|-|\.|@)+}}/g;
+  var regex = /{{(\w|:|[\s-+.,@/\//()?=*_])+}}/g;
 
   return function (str){
     if(regex.test(str)){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-templates",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Simple JSON value templating.",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -83,13 +83,33 @@ describe("json-template", function() {
       assert.equal(template(), "now-24h");
     });
 
-    it("should handle 'at' symbol in defaults", function() {
+    it("should handle special characters in defaults", function() {
+      var template = parse("{{foo:-+., @\/()?=*_}}");
+      assert.deepEqual(template.parameters, [{ key: "foo", defaultValue: "-+., @\/()?=*_" }]);
+      assert.equal(template({ foo: "-+., @\/()?=*_"}), "-+., @\/()?=*_");
+      assert.equal(template(), "-+., @\/()?=*_");
+    });
+
+    it("should handle email address in defaults", function() {
       var template = parse("{{email:jdoe@mail.com}}");
       assert.deepEqual(template.parameters, [{ key: "email", defaultValue: "jdoe@mail.com" }]);
       assert.equal(template({ email: "jdoe@mail.com"}), "jdoe@mail.com");
       assert.equal(template(), "jdoe@mail.com");
     });
 
+    it("should handle phone number in defaults", function() {
+      var template = parse("{{phone:+1 (256) 34-34-4556}}");
+      assert.deepEqual(template.parameters, [{ key: "phone", defaultValue: "+1 (256) 34-34-4556" }]);
+      assert.equal(template({ phone: "+1 (256) 34-34-4556"}), "+1 (256) 34-34-4556");
+      assert.equal(template(), "+1 (256) 34-34-4556");
+    });
+
+    it("should handle url in defaults", function() {
+      var template = parse("{{url:http://www.host.com/path?key_1=value}}");
+      assert.deepEqual(template.parameters, [{ key: "url", defaultValue: "http://www.host.com/path?key_1=value" }]);
+      assert.equal(template({ url: "http://www.host.com/path?key_1=value"}), "http://www.host.com/path?key_1=value");
+      assert.equal(template(), "http://www.host.com/path?key_1=value");
+    });
   });
 
 


### PR DESCRIPTION
json-template
    strings
      ✓ should compute template for a string with a single parameter
      ✓ should compute template for strings with no parameters
      ✓ should compute template with default for a string
      ✓ should compute template with default for a string with multiple colons
      ✓ should compute template for a string with inner parameter
      ✓ should compute template for a string with multiple inner parameters
      ✓ should handle extra whitespace
      ✓ should handle dashes in defaults
      ✓ should handle special characters in defaults
      ✓ should handle email address in defaults
      ✓ should handle phone number in defaults
      ✓ should handle url in defaults
    objects
      ✓ should compute template with an object that has inner parameter
      ✓ should compute template with an object
      ✓ should compute template with an object with multiple parameters
      ✓ should compute template with nested objects
      ✓ should compute template keys
      ✓ should compute template keys with default value
      ✓ should compute template keys with default value and period in the string
    arrays
      ✓ should compute template with an array
      ✓ should compute template with a nested array
    unknown types
      ✓ should compute template with numbers
      ✓ should compute template with booleans
      ✓ should compute template with dates
      ✓ should compute template with functions
    mixed data structures
      ✓ should compute template with ElasticSearch query
      ✓ should compute template with ElasticSearch query including default value
      ✓ should compute template with ElasticSearch query including arrays


  28 passing (21ms)