### PR TITLE
Nested object parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ console.log(template.parameters); // Prints [{ key: "foo.value", defaultValue: "
 console.log(template()); // Prints "baz", using the default value.
 
 console.log(template({ foo: { value: 'bar' } })); // Prints "bar", using the given value.
+
+// Example with parameter coming from array
+var template = parse({ a: "{{foo.1:baz}}" });
+
+console.log(template.parameters); // Prints [{ key: "foo.1", defaultValue: "baz" }]
+
+console.log(template()); // Prints { a: "baz" }, using the default value.
+
+console.log(template({ foo: ["baq", "bar"] })); // Prints { a: "bar" }, using the given value of array.
 ```
 
 The kind of templating you can see in the above examples gets applied to any string values in complex object structures such as ElasticSearch queries. Here's an example of an ElasticSearch query.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ console.log(template()); // Prints "bar", using the default value.
 console.log(template({ foo: "baz" })); // Prints "baz", using the given value.
 ```
 
+Parameters can come from a nested object.
+
+```js
+var template = parse("{{foo.value:baz}}");
+
+console.log(template.parameters); // Prints [{ key: "foo.value", defaultValue: "baz" }]
+
+console.log(template()); // Prints "baz", using the default value.
+
+console.log(template({ foo: { value: 'bar' } })); // Prints "bar", using the given value.
+```
+
 The kind of templating you can see in the above examples gets applied to any string values in complex object structures such as ElasticSearch queries. Here's an example of an ElasticSearch query.
 
 ```js

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 //
 // By Curran Kelleher and Chrostophe Serafin
 // November 2016
+var objectPath = require("object-path");
 
 module.exports = parse;
 
@@ -11,7 +12,7 @@ module.exports = parse;
 //
 // Returns a function `template(context)` that will "fill in" the template
 // with the context object passed to it.
-// 
+//
 // The returned function has a `parameters` property,
 // which is an array of parameter descriptor objects,
 // each of which has a `key` property and possibly a `defaultValue` property.
@@ -57,7 +58,7 @@ var parseString = (function (){
         context = context || {};
         return matches.reduce(function (str, match, i){
           var parameter = parameters[i];
-          var value = context[parameter.key] || parameter.defaultValue;
+          var value = objectPath.get(context, parameter.key) || parameter.defaultValue;
           return str.replace(match, value);
         }, str);
       }, parameters);

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "homepage": "https://github.com/datavis-tech/json-templates#readme",
   "devDependencies": {
     "mocha": "^3.0.2"
+  },
+  "dependencies": {
+    "object-path": "^0.11.4"
   }
 }

--- a/test.js
+++ b/test.js
@@ -19,6 +19,13 @@ describe("json-template", function() {
       assert.equal(template({ foo: "bar" }), "bar");
     });
 
+    it("should compute template for a string with a nested object parameter", function() {
+      var template = parse('{{foo.bar:baz}}');
+      assert.deepEqual(template.parameters, [{ key: "foo.bar", defaultValue: 'baz'} ]);
+      assert.equal(template({ foo: { bar: 'message' } }), "message");
+      assert.equal(template(), "baz");
+    });
+
     it("should compute template for strings with no parameters", function() {
       [
         "foo",

--- a/test.js
+++ b/test.js
@@ -158,6 +158,13 @@ describe("json-template", function() {
 
     });
 
+    it("should compute template for an object with a nested object parameter", function() {
+      var template = parse({ a: "{{foo.1:baz}}" });
+      assert.deepEqual(template.parameters, [{ key: "foo.1", defaultValue: 'baz'} ]);
+      assert.deepEqual(template({ foo: ["baq", "bar"] }), { a: "bar" });
+      assert.deepEqual(template(), { a: "baz" });
+    });
+
     it("should compute template with nested objects", function() {
 
       var template = parse({

--- a/test.js
+++ b/test.js
@@ -20,9 +20,9 @@ describe("json-template", function() {
     });
 
     it("should compute template for a string with a nested object parameter", function() {
-      var template = parse('{{foo.bar:baz}}');
-      assert.deepEqual(template.parameters, [{ key: "foo.bar", defaultValue: 'baz'} ]);
-      assert.equal(template({ foo: { bar: 'message' } }), "message");
+      var template = parse('{{foo.value:baz}}');
+      assert.deepEqual(template.parameters, [{ key: "foo.value", defaultValue: 'baz'} ]);
+      assert.equal(template({ foo: { value: 'bar' } }), "bar");
       assert.equal(template(), "baz");
     });
 


### PR DESCRIPTION

  json-template
    strings
      ✓ should compute template for a string with a single parameter
      ✓ should compute template for a string with a nested object parameter
      ✓ should compute template for strings with no parameters
      ✓ should compute template with default for a string
      ✓ should compute template with default for a string with multiple colons
      ✓ should compute template for a string with inner parameter
      ✓ should compute template for a string with multiple inner parameters
      ✓ should handle extra whitespace
      ✓ should handle dashes in defaults
      ✓ should handle special characters in defaults
      ✓ should handle email address in defaults
      ✓ should handle phone number in defaults
      ✓ should handle url in defaults
    objects
      ✓ should compute template with an object that has inner parameter
      ✓ should compute template with an object
      ✓ should compute template with an object with multiple parameters
      ✓ should compute template for an object with a nested object parameter
      ✓ should compute template with nested objects
      ✓ should compute template keys
      ✓ should compute template keys with default value
      ✓ should compute template keys with default value and period in the string
    arrays
      ✓ should compute template with an array
      ✓ should compute template with a nested array
    unknown types
      ✓ should compute template with numbers
      ✓ should compute template with booleans
      ✓ should compute template with dates
      ✓ should compute template with functions
    mixed data structures
      ✓ should compute template with ElasticSearch query
      ✓ should compute template with ElasticSearch query including default value
      ✓ should compute template with ElasticSearch query including arrays


  30 passing (23ms)