### PR TITLE
feat: add null replacemed when no template match on the context

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,10 @@ const parseString = (() => {
             return value;
           }
 
+          if (value === undefined) {
+            return null;
+          }
+
           return str.replace(match, value);
         }, str);
       };

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ const parseString = (() => {
             return value;
           }
 
-          if (value === undefined) {
+          if (value === undefined || value === null) {
             return null;
           }
 

--- a/test.js
+++ b/test.js
@@ -92,10 +92,10 @@ describe('json-template', () => {
     });
 
     it('should handle special characters in defaults', () => {
-      const template = parse('{{foo:-+., @\/()?=*_}}');
-      assert.deepEqual(template.parameters, [{ key: 'foo', defaultValue: '-+., @\/()?=*_' }]);
-      assert.equal(template({ foo: '-+., @\/()?=*_' }), '-+., @\/()?=*_');
-      assert.equal(template(), '-+., @\/()?=*_');
+      const template = parse('{{foo:-+., @/()?=*_}}');
+      assert.deepEqual(template.parameters, [{ key: 'foo', defaultValue: '-+., @/()?=*_' }]);
+      assert.equal(template({ foo: '-+., @/()?=*_' }), '-+., @/()?=*_');
+      assert.equal(template(), '-+., @/()?=*_');
     });
 
     it('should handle email address in defaults', () => {
@@ -544,6 +544,19 @@ describe('json-template', () => {
       };
       assert.deepEqual(template.parameters, [{ key: 'c.d' }]);
       assert.equal(JSON.stringify(template(context)), JSON.stringify(expected));
+    });
+  });
+
+  // This section tests that if the match is not found the template should be replaced by null
+  describe('no match on the given context', () => {
+    it('should replace the given template by null if no match found for an string', () => {
+      const template = parse('{{foo}}');
+      assert.equal(template({}), null);
+    });
+
+    it('should replace the given template by null if no match found for an object', () => {
+      const template = parse({ boo: '{{foo}}' });
+      assert.deepEqual(template({}), { boo: null });
     });
   });
 });

--- a/test.js
+++ b/test.js
@@ -558,5 +558,10 @@ describe('json-template', () => {
       const template = parse({ boo: '{{foo}}' });
       assert.deepEqual(template({}), { boo: null });
     });
+
+    it('should replace the given template by null if the found value is null', () => {
+      const template = parse({ boo: '{{foo}}' });
+      assert.deepEqual(template({ foo: null }), { boo: null });
+    });
   });
 });


### PR DESCRIPTION
![](https://media.giphy.com/media/yoJC2A59OCZHs1LXvW/giphy.gif)

- Replace the not found template match with null instead of 'undefined' as string
- Replace the null values with proper null not string "null"

Closes #20 