### PR TITLE
Handle empty strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,10 @@ const parseString = (() => {
         context = context || {};
         return matches.reduce((str, match, i) => {
           const parameter = parameters[i];
-          const value = objectPath.get(context, parameter.key) || parameter.defaultValue;
+          let value = objectPath.get(context, parameter.key)
+          if (value === undefined) {
+            value = parameter.defaultValue;
+          }
 
           if (typeof value === 'object') {
             return value;

--- a/test.js
+++ b/test.js
@@ -125,6 +125,11 @@ describe('json-template', () => {
       );
       assert.equal(template(), 'http://www.host.com/path?key_1=value');
     });
+
+    it('should handle empty strings for parameter value', () => {
+      const template = parse('{{foo}}');
+      assert.equal(template({ foo: '' }), '');
+    });
   });
 
   // This section tests that the parse function recursively


### PR DESCRIPTION
Hi,

I noticed that the templating system seems to be having issues with empty strings (and other values resulting in `if (value)` evaluating to `false`) as parameter values:

`parse('{{foo}}')({ foo: '' })` returns `null` (in fact, the `defaultValue`) instead of `''`

I added a test for this edge case, and fixed it.

Tell me what you think 🙂

Cheers,

Flo