### PR TITLE
Bug Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ const parseString = (() => {
           }
 
           if (typeof value === 'function') {
-            return value();
+            value = value();
           }
 
           if (typeof value === 'object') {


### PR DESCRIPTION
Content returning without replacing the parameter's value while the type of parameter is a function in the passed context.