### PR TITLE
Bug Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ const parseString = (() => {
           }
 
           if (typeof value === 'function') {
-            return value();
+            value = value();
           }
 
           if (typeof value === 'object') {

--- a/test.js
+++ b/test.js
@@ -313,6 +313,12 @@ describe('json-template', () => {
       assert.deepEqual(template.parameters, [{ key: 'userCard' }]);
       assert.deepEqual(template({ userCard: () => ({ id: 1, user: "John" }) }), [{ id: 1, user: "John" }]);
     });
+
+    it('should compute template with function with multiple inner parameters', () => {
+      const template = parse(JSON.stringify({ username: "{{username}}", password: "{{password}}" }));
+      assert.deepEqual(template.parameters, [{ key: 'username' }, { key: 'password' }]);
+      assert.equal(template({ username: () => ("John"), password: () => ("John") }), '{"username":"John","password":"John"}');
+    });
   });
 
   // This section tests that arbitrary types may be present


### PR DESCRIPTION
Content returning without replacing the parameter's value while the type of parameter is a function in the passed context.