### PR TITLE
Fix value inside string and date to ISO string

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,17 +98,18 @@ const parseString = (() => {
             value = value();
           }
 
-          if (typeof value === 'object' && value !== null) {
-            return value;
-          }
-
-          // Accommodate numbers as values.
+          // Accommodate non-string as original values.
           if (
             matches.length === 1 &&
             str.startsWith('{{') &&
             str.endsWith('}}')
           ) {
             return value;
+          }
+
+          // Treat Date value inside string to ISO string.
+          if (value instanceof Date) {
+            value = value.toISOString();
           }
 
           return result.replace(match, value == null ? '' : value);

--- a/test.js
+++ b/test.js
@@ -375,6 +375,12 @@ describe('json-template', () => {
       const now = new Date();
       assert.strictEqual(template({ now }), now);
     });
+
+    it('should compute template with Date', () => {
+      const template = parse('a{{now}}');
+      const now = new Date();
+      assert.strictEqual(template({ now }), `a${now.toISOString()}`);
+    });
   });
 
   // This section tests that arbitrary types may be present

--- a/test.js
+++ b/test.js
@@ -154,6 +154,11 @@ describe('json-template', () => {
       const template = parse('{{foo}} {{bar}}');
       assert.equal(template({ foo: null }), ' ');
     });
+
+    it('number variable inside string should be replaced', () => {
+      const result = parse('abc{{a}}def')({ a: 1 });
+      assert.equal(result, 'abc1def');
+    });
   });
 
   // This section tests that the parse function recursively


### PR DESCRIPTION
Values inside of a string should not be returned as only the value. Better to be replaced to `.toString()`ed string value and join the template.

Example:

```
parse('abc{{a}}def')({ a: 1 }) // should be 'abc1def' but 1 for now
```

Additionally, the default `toString()` on `Date` value produce a readable string, but hard to use. So when date variable inside a string, change it by `.toISOString()`.